### PR TITLE
Support heartbeat type parameter

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -25,7 +25,7 @@ import (
 
 var validHeartbeatTypes = map[string]string{
 	"legacy":  "event: heartbeat\n\n",
-	"message": "event: message\r\ndata: heartbeat\r\n\n",
+	"message": "event: message\r\ndata: heartbeat\r\n\r\n",
 }
 
 var (


### PR DESCRIPTION
https://github.com/ton-blockchain/ton-connect/pull/93/

I test it locally

```
# backwards compatibility
curl "http://localhost:8081/bridge/events?client_id=test_valid"  

event: heartbeat

event: heartbeat

# invalid type
curl "http://localhost:8081/bridge/events?client_id=test_valid&heartbeat=callmedenchick" 

{"message":"invalid heartbeat type. Supported: legacy and message","statusCode":400}

# legacy type
curl "http://localhost:8081/bridge/events?client_id=test_valid&heartbeat=legacy"        

event: heartbeat

event: heartbeat

# message type
curl "http://localhost:8081/bridge/events?client_id=test_valid&heartbeat=message" 

event: message
data: heartbeat
```