### PR TITLE
fix valkey uri parsing

### DIFF
--- a/internal/storage/valkey.go
+++ b/internal/storage/valkey.go
@@ -26,27 +26,36 @@ func NewValkeyStorage(valkeyURI string) (*ValkeyStorage, error) {
 	log := log.WithField("prefix", "NewValkeyStorage")
 
 	uris := strings.Split(valkeyURI, ",")
-	addrs := make([]string, len(uris))
-	var password string
-
-	for i, uri := range uris {
-		opts, err := redis.ParseURL(strings.TrimSpace(uri))
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse URI %d: %w", i+1, err)
-		}
-		addrs[i] = opts.Addr
-		if i == 0 {
-			password = opts.Password
-		}
-	}
 
 	var client redis.UniversalClient
 	if len(uris) > 1 {
+		addrs := make([]string, len(uris))
+		// TODO what if other options differ between nodes?
+		var firstOpts *redis.Options
+		for i, uri := range uris {
+			opts, err := redis.ParseURL(strings.TrimSpace(uri))
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse URI %d: %w", i+1, err)
+			}
+			addrs[i] = opts.Addr
+			if i == 0 {
+				firstOpts = opts
+			}
+		}
 		log.Infof("Using cluster mode with %d nodes", len(uris))
-		client = redis.NewClusterClient(&redis.ClusterOptions{Addrs: addrs, Password: password})
+		client = redis.NewClusterClient(&redis.ClusterOptions{
+			Addrs:     addrs,
+			Password:  firstOpts.Password,
+			Username:  firstOpts.Username,
+			TLSConfig: firstOpts.TLSConfig,
+		})
 	} else {
+		opts, err := redis.ParseURL(strings.TrimSpace(uris[0]))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse URI: %w", err)
+		}
 		log.Info("Using single-node mode")
-		client = redis.NewClient(&redis.Options{Addr: addrs[0], Password: password})
+		client = redis.NewClient(opts)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
How it was before:

```
➜  bridge3 git:(main) ✗ STORAGE=valkey VALKEY_URI=rediss://denchick:yourpassword@localhost:6380?skip_verify=true ./bridge
INFO[0000] Bridge is running                            
INFO[0000] Using Valkey storage                         
INFO[0000] Using single-node mode                        prefix=NewValkeyStorage
FATA[0000] failed to create storage: connection failed: read: connection reset by peer 
```

How is it now:

```
➜  bridge3 git:(main) ✗ STORAGE=valkey STORAGE=valkey VALKEY_URI=rediss://denchick:yourpassword@localhost:6380?skip_verify=true ./bridge
INFO[0000] Bridge is running                            
INFO[0000] Using Valkey storage                         
INFO[0000] Using single-node mode                        prefix=NewValkeyStorage
INFO[0000] Successfully connected to Valkey              prefix=NewValkeyStorage
INFO[0000] Using Valkey/Redis storage                   
INFO[0000] Valkey is healthy                             prefix=ValkeyStorage.HealthCheck

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.13.4
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8081
```