### PR TITLE
docs: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
-# Bridge
+# TON Connect Bridge v3
 
-This repository was merged with https://github.com/ton-connect/bridge
+> ⚠️ **DEPRECATED**
+>
+> This repository has been merged into [ton-connect/bridge](https://github.com/ton-connect/bridge). All development continues there.
+>
+> **What should I do?**
+> Use [ton-connect/bridge](https://github.com/ton-connect/bridge) — all features from bridge3 are now available there.
+>
+> **Why?**
+> We merged bridge3 into the main bridge repository to consolidate development and provide a single, well-maintained implementation.
+>
+> **Questions?**
+> Open an issue at [ton-connect/bridge](https://github.com/ton-connect/bridge/issues).


### PR DESCRIPTION
## Deprecation Notice

This repository is now deprecated and will no longer receive updates.

### What should I do?

Migrate to [ton-connect/bridge](https://github.com/ton-connect/bridge) — the actively maintained implementation with improved performance, clustering support, and regular updates.

### Why?

We're consolidating TON Connect bridge implementations into a single repository to provide better support and faster development.

### Questions?

Open an issue at [ton-connect/bridge](https://github.com/ton-connect/bridge/issues).